### PR TITLE
Add a section for related tools, move Midas/Tangelo/Clique there

### DIFF
--- a/css/agency.css
+++ b/css/agency.css
@@ -4,6 +4,22 @@
  * For details, see http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+.footer-divider {
+    width: 90%;
+    height: 6px;
+    border-top: 3px solid #888;
+    border-bottom: 1px solid #777;
+    margin: 0 auto;
+}
+
+.related-tools {
+    padding-top: 10px;
+}
+
+.related-tools-img {
+    width: 100px;
+}
+
 body {
     overflow-x: hidden;
     font-family: "Roboto Slab","Helvetica Neue",Helvetica,Arial,sans-serif;

--- a/index.html
+++ b/index.html
@@ -331,11 +331,14 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">Resonant Data</h2>
-                    <h3 class="section-subheading text-muted">Take control of your data. Resonant is composed of these open-source solutions for data management.</h3>
+                    <h3 class="section-subheading text-muted">
+                        Take control of your data. <b>Girder</b> is Resonant's data management platform for building rich
+                        data-driven applications and services.
+                    </h3>
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-4 col-sm-offset-2">
+                <div class="col-sm-4 col-sm-offset-4">
                     <div class="team-member">
                         <a href="http://girder.readthedocs.org/">
                             <img src="img/team/girder.png" class="img-responsive img-circle" alt="">
@@ -352,23 +355,6 @@
                         </ul>
                     </div>
                 </div>
-                <div class="col-sm-4">
-                    <div class="team-member">
-                        <a href="http://www.midasplatform.org/">
-                            <img src="img/team/midas.png" class="img-responsive img-circle" alt="">
-                            <h4>Midas</h4>
-                        </a>
-                        <p class="text-muted">Data management for your LAMP stack.</p>
-                        <ul class="list-inline social-buttons">
-                            <li><a href="http://www.midasplatform.org/"><i class="fa fa-home"></i></a>
-                            </li>
-                            <li><a href="http://midas-server.readthedocs.org/"><i class="fa fa-graduation-cap"></i></a>
-                            </li>
-                            <li><a href="https://github.com/midasplatform/Midas"><i class="fa fa-git"></i></a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
             </div>
         </div>
     </section>
@@ -378,41 +364,21 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">Resonant Analytics</h2>
-                    <h3 class="section-subheading text-muted">Resonant solutions for data processing are crafted from these powerful open-source libraries.</h3>
+                    <h3 class="section-subheading text-muted">Execute distributed processing pipelines on your data.</h3>
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-4 col-sm-offset-2">
+                <div class="col-sm-4 col-sm-offset-4">
                     <div class="team-member">
                         <a href="http://girder-worker.readthedocs.org/">
-                            <img src="img/team/girder.png" class="img-responsive img-circle" alt="">
+                            <img src="img/team/girder.png" class="img-responsive img-circle" alt="" />
                             <h4>Girder Worker</h4>
                         </a>
-                        <p class="text-muted">Workflows for data science. Mix and match what makes sense from both Python and R.</p>
+                        <p class="text-muted">Scalable workflows for data science.</p>
                         <ul class="list-inline social-buttons">
-                            <li><a href="http://girder-worker.readthedocs.org/"><i class="fa fa-home"></i></a>
-                            </li>
-                            <li><a href="http://girder-worker.readthedocs.org/en/latest/api-docs.html"><i class="fa fa-graduation-cap"></i></a>
-                            </li>
-                            <li><a href="https://github.com/girder/girder_worker"><i class="fa fa-git"></i></a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="col-sm-4">
-                    <div class="team-member">
-                        <a href="http://tangelo.readthedocs.org/">
-                            <img src="img/team/tangelo.png" class="img-responsive img-circle" alt="">
-                            <h4>Tangelo</h4>
-                        </a>
-                        <p class="text-muted">Turn Python scripts into web services. No web education needed.</p>
-                        <ul class="list-inline social-buttons">
-                            <li><a href="http://tangelo.readthedocs.org/"><i class="fa fa-home"></i></a>
-                            </li>
-                            <li><a href="http://tangelo.readthedocs.org/en/latest/tutorials/building-an-app.html"><i class="fa fa-graduation-cap"></i></a>
-                            </li>
-                            <li><a href="https://github.com/Kitware/tangelo"><i class="fa fa-git"></i></a>
-                            </li>
+                            <li><a href="http://girder-worker.readthedocs.org/"><i class="fa fa-home"></i></a></li>
+                            <li><a href="http://girder-worker.readthedocs.org/en/latest/api-docs.html"><i class="fa fa-graduation-cap"></i></a></li>
+                            <li><a href="https://github.com/girder/girder_worker"><i class="fa fa-git"></i></a></li>
                         </ul>
                     </div>
                 </div>
@@ -429,7 +395,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-4 col-sm-offset-2">
+                <div class="col-sm-4 col-sm-offset-4">
                     <div class="team-member">
                         <a href="http://geojs.readthedocs.org/">
                             <img src="img/team/geojs.png" class="img-responsive img-circle" alt="">
@@ -446,11 +412,57 @@
                         </ul>
                     </div>
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <aside class="related-tools">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h3 class="section-heading text-muted">Related tools</h3>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-4">
+                    <div class="team-member">
+                        <a href="http://tangelo.readthedocs.org/">
+                            <img src="img/team/tangelo.png" class="related-tools-img img-responsive img-circle" alt="">
+                            <h5>Tangelo</h5>
+                        </a>
+                        <p class="text-muted">Turn Python scripts into web services. No web education needed.</p>
+                        <ul class="list-inline social-buttons">
+                            <li><a href="http://tangelo.readthedocs.org/"><i class="fa fa-home"></i></a>
+                            </li>
+                            <li><a href="http://tangelo.readthedocs.org/en/latest/tutorials/building-an-app.html"><i class="fa fa-graduation-cap"></i></a>
+                            </li>
+                            <li><a href="https://github.com/Kitware/tangelo"><i class="fa fa-git"></i></a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <div class="team-member">
+                        <a href="http://www.midasplatform.org/">
+                            <img src="img/team/midas.png" class="related-tools-img img-responsive img-circle" alt="">
+                            <h5>Midas</h5>
+                        </a>
+                        <p class="text-muted">Data management for your LAMP stack.</p>
+                        <ul class="list-inline social-buttons">
+                            <li><a href="http://www.midasplatform.org/"><i class="fa fa-home"></i></a>
+                            </li>
+                            <li><a href="http://midas-server.readthedocs.org/"><i class="fa fa-graduation-cap"></i></a>
+                            </li>
+                            <li><a href="https://github.com/midasplatform/Midas"><i class="fa fa-git"></i></a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
                 <div class="col-sm-4">
                     <div class="team-member">
                         <a href="https://github.com/XDATA-Year-3/clique#readme">
-                            <img src="img/team/clique.png" class="img-responsive img-circle" alt="">
-                            <h4>Clique</h4>
+                            <img src="img/team/clique.png" class="related-tools-img img-responsive img-circle" alt="">
+                            <h5>Clique</h5>
                         </a>
                         <p class="text-muted">Intuitive large graph visualization and curation.</p>
                         <ul class="list-inline social-buttons">
@@ -465,7 +477,9 @@
                 </div>
             </div>
         </div>
-    </section>
+    </aside>
+
+    <div class="footer-divider"></div>
 
     <footer>
         <div class="container">
@@ -937,17 +951,17 @@
                                 <img class="img-responsive img-centered" src="img/portfolio/sumo-preview.png" alt="">
                             </a>
                             <p class="portfolio-description">
-The SUMO collective laboratory works on problems of computational biology while
-leveraging methods from bioinformatics, visualization, and image analysis. The
-group, led by Ohio State University, has engineered several workflows for
-processing and analyzing images for problems in cancer, neuro, and wound biology
-and immunology. They have developed algorithms that have been adapted for
-exploration in the laboratory at the microscopic scale (confocal, brightfield,
-histology, etc.) and in radiology clinics (diffusion tensor MR, fMRI, etc.).
-Kitware has assisted this group with developing online software to share these
-algorithms and visualizations to a wide audience. The SUMO software enables
-researchers to analyze data through a web interface supported by Girder and
-Girder Worker.
+                                The SUMO collective laboratory works on problems of computational biology while
+                                leveraging methods from bioinformatics, visualization, and image analysis. The
+                                group, led by Ohio State University, has engineered several workflows for
+                                processing and analyzing images for problems in cancer, neuro, and wound biology
+                                and immunology. They have developed algorithms that have been adapted for
+                                exploration in the laboratory at the microscopic scale (confocal, brightfield,
+                                histology, etc.) and in radiology clinics (diffusion tensor MR, fMRI, etc.).
+                                Kitware has assisted this group with developing online software to share these
+                                algorithms and visualizations to a wide audience. The SUMO software enables
+                                researchers to analyze data through a web interface supported by Girder and
+                                Girder Worker.
                             </p>
                             <p class="portfolio-description">
                                 For more information, visit <a href="http://osumo.org">http://osumo.org</a>.

--- a/index.html
+++ b/index.html
@@ -395,7 +395,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-sm-4 col-sm-offset-4">
+                <div class="col-sm-4 col-sm-offset-2">
                     <div class="team-member">
                         <a href="http://geojs.readthedocs.org/">
                             <img src="img/team/geojs.png" class="img-responsive img-circle" alt="">
@@ -408,6 +408,21 @@
                             <li><a href="http://opengeoscience.github.io/geojs/examples/index.html"><i class="fa fa-graduation-cap"></i></a>
                             </li>
                             <li><a href="https://github.com/OpenGeoscience/geojs"><i class="fa fa-git"></i></a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <div class="team-member">
+                        <a href="http://geojs.readthedocsx.org/">
+                            <img src="img/Resonant_Mark_256.png" height="225" width = "225" class="img-responsive img-circle" alt="">
+                            <h4>Candela</h4>
+                        </a>
+                        <p class="text-muted">Reusable visualization components for the web.</p>
+                        <ul class="list-inline social-buttons">
+                            <li><a href="https://github.com/Kitware/candela/tree/master/src/candela#readme"><i class="fa fa-home"></i></a>
+                            </li>
+                            <li><a href="https://github.com/Kitware/candela"><i class="fa fa-git"></i></a>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
This implements the "and friends" section @jeffbaumes suggested. Feel free to tweak as you see fit.

Along with this change, I'd like to do the following:
- [ ] Add a section for Cumulus/HPCCloud where Tangelo used to be
- [x] Add a section for Candela where Clique used to be
- [ ] Change the logo for the girder worker to make it not the exact same one as Girder. (We don't have one yet AFAIK.)
