### PR TITLE
Remove link to nonfunctional demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -834,9 +834,7 @@
                             <!-- Project Details Go Here -->
                             <h2>Ebola Outbreak</h2>
                             <p class="item-intro text-muted">Storytelling with data</p>
-                            <a href="http://xdata.kitware.com/ebola">
-                                <img class="img-responsive img-centered" src="img/portfolio/ebola-preview.png" alt="">
-                            </a>
+                            <img class="img-responsive img-centered" src="img/portfolio/ebola-preview.png" alt="">
                             <p class="portfolio-description">
                                 In order to increase awareness of the 2014 Ebola outbreak in western Africa, we developed an
                                 interactive visualization timeline. The timeline aggregates news, case count information, and a
@@ -854,9 +852,6 @@
                                 The Air Force Research Laboratory and the Defense Advanced Research Projects Agency
                                 XDATA program sponsored the effort to create the timeline and the map, while HealthMap
                                 provided the news articles used in the timeline.
-                            </p>
-                            <p class="portfolio-description">
-                                For more information, visit <a href="http://xdata.kitware.com/ebola/timeline">http://xdata.kitware.com/ebola/timeline</a>.
                             </p>
                             <p class="portfolio-components">Resonant components:
                                 <a href="#analytics" class="page-scroll" data-dismiss="modal">Tangelo</a>,


### PR DESCRIPTION
This would cause a redirect loop if xdata.kitware.com just pointed back to the Resonant site.